### PR TITLE
fix(admin): dedupe react 解决白屏问题

### DIFF
--- a/apps/aiget/admin/www/vite.config.ts
+++ b/apps/aiget/admin/www/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    dedupe: ['react', 'react-dom'],
   },
   server: {
     port: 5174,

--- a/apps/moryflow/admin/vite.config.ts
+++ b/apps/moryflow/admin/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -9,6 +9,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    dedupe: ['react', 'react-dom'],
   },
   server: {
     port: 5173,
@@ -32,4 +33,4 @@ export default defineConfig({
       },
     },
   },
-})
+});


### PR DESCRIPTION
## 问题

aiget admin 打开白屏，控制台报错：
```
Uncaught TypeError: Cannot read properties of null (reading 'useCallback')
```

## 原因

React 被打包了多份实例，hooks 上下文不共享。console 应用已修复（commit 1c47b55），admin 没同步。

## 修复

在 Vite 配置添加 `dedupe: ['react', 'react-dom']`：
- `apps/aiget/admin/www/vite.config.ts`
- `apps/moryflow/admin/vite.config.ts`（预防）

## 验证

- [x] 构建通过
- [x] 类型检查通过