### PR TITLE
Moryflow PC: improve AI provider settings UX

### DIFF
--- a/apps/moryflow/pc/CLAUDE.md
+++ b/apps/moryflow/pc/CLAUDE.md
@@ -20,6 +20,10 @@ Moryflow 桌面端应用，基于 Electron + React 构建。
 - 渲染进程使用 TailwindCSS
 - 主进程处理文件系统、网络、Agent 运行时等重操作
 - 敏感操作（文件访问、网络请求）必须在主进程执行
+- Providers 设置页的“测试连接”必须基于用户已启用模型的第一个（不允许写死默认模型做 fallback）
+- 当用户填写 API Key 或开启任意模型时，UI 应自动开启对应服务商，避免“已配置但忘记启用”
+- Custom Provider 必须支持模型列表管理（添加/启用/禁用/删除），否则无法测试与选择模型
+- Providers 左侧列表仅保留“会员模型 + Providers”两类；Providers 内部排序为启用在上、未启用在下，并在切换 active provider 时才刷新顺序（避免编辑时跳动）
 - 全局样式引入 `/ui/styles`，Electron 专属样式保留在 `src/renderer/global.css`
 - `electron.vite.config.ts` 需为 `/ui/styles` 设置别名，避免解析到 `packages/ui/src`
 

--- a/apps/moryflow/pc/src/main/app/ipc-handlers.ts
+++ b/apps/moryflow/pc/src/main/app/ipc-handlers.ts
@@ -1,7 +1,15 @@
-import { existsSync } from 'node:fs'
-import { app, BrowserWindow, ipcMain } from 'electron'
-import { getProviderById } from '../../shared/model-registry/index.js'
-import type { VaultTreeNode } from '../../shared/ipc.js'
+/**
+ * [INPUT]: IPC payloads from renderer/preload
+ * [OUTPUT]: IPC handler results (plain JSON, serializable)
+ * [POS]: Main process IPC router (validation + orchestration only)
+ *
+ * [PROTOCOL]: 本文件变更时，必须更新此 Header 及所属目录 CLAUDE.md
+ */
+
+import { existsSync } from 'node:fs';
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { getProviderById, toApiModelId } from '../../shared/model-registry/index.js';
+import type { VaultTreeNode } from '../../shared/ipc.js';
 import {
   createVault,
   createVaultFile,
@@ -23,11 +31,11 @@ import {
   selectDirectory,
   showItemInFinder,
   writeVaultFile,
-} from '../vault.js'
-import { getAgentSettings, updateAgentSettings } from '../agent-settings/index.js'
-import { resetApp } from '../app-maintenance.js'
-import { getAllPreloadCache, setPreloadCache } from '../preload-cache.js'
-import { getPreloadConfig, setPreloadConfig } from '../preload-settings.js'
+} from '../vault.js';
+import { getAgentSettings, updateAgentSettings } from '../agent-settings/index.js';
+import { resetApp } from '../app-maintenance.js';
+import { getAllPreloadCache, setPreloadCache } from '../preload-cache.js';
+import { getPreloadConfig, setPreloadConfig } from '../preload-settings.js';
 import {
   getExpandedPaths,
   setExpandedPaths,
@@ -36,13 +44,13 @@ import {
   getOpenTabs,
   setOpenTabs,
   type PersistedTab,
-} from '../workspace-settings.js'
-import { getTreeCache, setTreeCache } from '../tree-cache.js'
-import type { VaultWatcherController } from '../vault-watcher/index.js'
-import { getRuntime } from '../chat/runtime.js'
-import * as ollamaService from '../ollama-service/index.js'
-import { membershipBridge } from '../membership-bridge.js'
-import path from 'node:path'
+} from '../workspace-settings.js';
+import { getTreeCache, setTreeCache } from '../tree-cache.js';
+import type { VaultWatcherController } from '../vault-watcher/index.js';
+import { getRuntime } from '../chat/runtime.js';
+import * as ollamaService from '../ollama-service/index.js';
+import { membershipBridge } from '../membership-bridge.js';
+import path from 'node:path';
 import {
   cloudSyncEngine,
   cloudSyncApi,
@@ -52,339 +60,364 @@ import {
   readBinding,
   writeBinding,
   deleteBinding,
-} from '../cloud-sync/index.js'
-import { handleBindingConflictResponse } from '../cloud-sync/binding-conflict.js'
-import { fetchCurrentUserId } from '../cloud-sync/user-info.js'
+} from '../cloud-sync/index.js';
+import { handleBindingConflictResponse } from '../cloud-sync/binding-conflict.js';
+import { fetchCurrentUserId } from '../cloud-sync/user-info.js';
 
 type RegisterIpcHandlersOptions = {
-  vaultWatcherController: VaultWatcherController
-}
+  vaultWatcherController: VaultWatcherController;
+};
 
 /** 广播事件到所有窗口 */
 const broadcastToAllWindows = <T>(channel: string, payload: T): void => {
   for (const win of BrowserWindow.getAllWindows()) {
-    win.webContents.send(channel, payload)
+    win.webContents.send(channel, payload);
   }
-}
+};
 
 /**
  * 注册 main 进程的 IPC handlers，保持纯粹的参数校验和调用。
  */
 export const registerIpcHandlers = ({ vaultWatcherController }: RegisterIpcHandlersOptions) => {
-  ipcMain.handle('app:getVersion', () => app.getVersion())
-  ipcMain.handle('vault:getRecent', () => getStoredVault())
-  ipcMain.handle('vault:open', (_event, payload) => openVault(payload ?? {}))
-  ipcMain.handle('vault:create', (_event, payload) => createVault(payload ?? {}))
-  ipcMain.handle('vault:selectDirectory', () => selectDirectory())
+  ipcMain.handle('app:getVersion', () => app.getVersion());
+  ipcMain.handle('vault:getRecent', () => getStoredVault());
+  ipcMain.handle('vault:open', (_event, payload) => openVault(payload ?? {}));
+  ipcMain.handle('vault:create', (_event, payload) => createVault(payload ?? {}));
+  ipcMain.handle('vault:selectDirectory', () => selectDirectory());
 
   // ── 多 Vault 支持 ────────────────────────────────────────────
-  ipcMain.handle('vault:getVaults', () => getVaults())
+  ipcMain.handle('vault:getVaults', () => getVaults());
   ipcMain.handle('vault:getActiveVault', async () => {
-    const vault = await getActiveVaultInfo()
+    const vault = await getActiveVaultInfo();
     // 确保云同步引擎初始化（应用启动时）
     if (vault) {
-      await cloudSyncEngine.init(vault.path)
+      await cloudSyncEngine.init(vault.path);
     }
-    return vault
-  })
+    return vault;
+  });
   ipcMain.handle('vault:setActiveVault', async (_event, payload) => {
-    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : ''
-    if (!vaultId) return null
+    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : '';
+    if (!vaultId) return null;
 
     // 1. 停止当前云同步引擎（内部会清理 fileId 缓存）
-    cloudSyncEngine.stop()
+    cloudSyncEngine.stop();
 
     // 2. 切换活动 Vault
-    const vault = await switchVault(vaultId)
+    const vault = await switchVault(vaultId);
     if (vault) {
       // 3. 广播活动 Vault 变更事件
-      broadcastToAllWindows('vault:activeVaultChanged', vault)
+      broadcastToAllWindows('vault:activeVaultChanged', vault);
       // 4. 重新初始化 vault watcher
-      vaultWatcherController.scheduleStart(vault.path)
+      vaultWatcherController.scheduleStart(vault.path);
       // 5. 重新初始化云同步引擎
-      await cloudSyncEngine.init(vault.path)
+      await cloudSyncEngine.init(vault.path);
     }
-    return vault
-  })
+    return vault;
+  });
   ipcMain.handle('vault:removeVault', (_event, payload) => {
-    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : ''
-    if (!vaultId) return
-    removeVault(vaultId)
-    broadcastToAllWindows('vault:vaultsChanged', getVaults())
-  })
+    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : '';
+    if (!vaultId) return;
+    removeVault(vaultId);
+    broadcastToAllWindows('vault:vaultsChanged', getVaults());
+  });
   ipcMain.handle('vault:renameVault', (_event, payload) => {
-    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : ''
-    const name = typeof payload?.name === 'string' ? payload.name : ''
-    if (!vaultId || !name) return
-    updateVaultName(vaultId, name)
-    broadcastToAllWindows('vault:vaultsChanged', getVaults())
-  })
+    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : '';
+    const name = typeof payload?.name === 'string' ? payload.name : '';
+    if (!vaultId || !name) return;
+    updateVaultName(vaultId, name);
+    broadcastToAllWindows('vault:vaultsChanged', getVaults());
+  });
 
   // 验证工作区：检查目录是否存在，删除不存在的
   ipcMain.handle('vault:validateVaults', () => {
-    const vaults = getVaults()
-    const invalidIds: string[] = []
+    const vaults = getVaults();
+    const invalidIds: string[] = [];
 
     for (const vault of vaults) {
       if (!existsSync(vault.path)) {
-        invalidIds.push(vault.id)
+        invalidIds.push(vault.id);
       }
     }
 
     // 删除无效的工作区
     for (const id of invalidIds) {
-      removeVault(id)
+      removeVault(id);
     }
 
     // 如果有删除，广播更新
     if (invalidIds.length > 0) {
-      broadcastToAllWindows('vault:vaultsChanged', getVaults())
+      broadcastToAllWindows('vault:vaultsChanged', getVaults());
     }
 
-    return { removedCount: invalidIds.length }
-  })
+    return { removedCount: invalidIds.length };
+  });
 
   ipcMain.handle('vault:readTreeRoot', async (_event, payload) => {
-    const result = await readVaultTreeRoot(payload ?? {})
+    const result = await readVaultTreeRoot(payload ?? {});
     if (payload?.path) {
-      vaultWatcherController.scheduleStart(payload.path)
+      vaultWatcherController.scheduleStart(payload.path);
     }
-    return result
-  })
-  ipcMain.handle('vault:readTreeChildren', async (_event, payload) => readVaultTreeChildren(payload ?? {}))
+    return result;
+  });
+  ipcMain.handle('vault:readTreeChildren', async (_event, payload) =>
+    readVaultTreeChildren(payload ?? {})
+  );
   ipcMain.handle('workspace:getExpandedPaths', (_event, payload) => {
-    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : ''
-    if (!vaultPath) return []
-    return getExpandedPaths(vaultPath)
-  })
+    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : '';
+    if (!vaultPath) return [];
+    return getExpandedPaths(vaultPath);
+  });
   ipcMain.handle('workspace:setExpandedPaths', (_event, payload) => {
-    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : ''
-    const paths = Array.isArray(payload?.paths) ? payload.paths : []
-    if (!vaultPath) return
-    setExpandedPaths(vaultPath, paths)
-  })
+    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : '';
+    const paths = Array.isArray(payload?.paths) ? payload.paths : [];
+    if (!vaultPath) return;
+    setExpandedPaths(vaultPath, paths);
+  });
   ipcMain.handle('workspace:getLastOpenedFile', (_event, payload) => {
-    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : ''
-    if (!vaultPath) return null
-    return getLastOpenedFile(vaultPath)
-  })
+    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : '';
+    if (!vaultPath) return null;
+    return getLastOpenedFile(vaultPath);
+  });
   ipcMain.handle('workspace:setLastOpenedFile', (_event, payload) => {
-    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : ''
-    const filePath = payload?.filePath === null ? null : typeof payload?.filePath === 'string' ? payload.filePath : null
-    if (!vaultPath) return
-    setLastOpenedFile(vaultPath, filePath)
-  })
+    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : '';
+    const filePath =
+      payload?.filePath === null
+        ? null
+        : typeof payload?.filePath === 'string'
+          ? payload.filePath
+          : null;
+    if (!vaultPath) return;
+    setLastOpenedFile(vaultPath, filePath);
+  });
   ipcMain.handle('workspace:getOpenTabs', (_event, payload) => {
-    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : ''
-    if (!vaultPath) return []
-    return getOpenTabs(vaultPath)
-  })
+    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : '';
+    if (!vaultPath) return [];
+    return getOpenTabs(vaultPath);
+  });
   ipcMain.handle('workspace:setOpenTabs', (_event, payload) => {
-    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : ''
-    const tabs = Array.isArray(payload?.tabs) ? (payload.tabs as PersistedTab[]) : []
-    if (!vaultPath) return
-    setOpenTabs(vaultPath, tabs)
-  })
-  ipcMain.handle('preload:getCache', () => getAllPreloadCache())
+    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : '';
+    const tabs = Array.isArray(payload?.tabs) ? (payload.tabs as PersistedTab[]) : [];
+    if (!vaultPath) return;
+    setOpenTabs(vaultPath, tabs);
+  });
+  ipcMain.handle('preload:getCache', () => getAllPreloadCache());
   ipcMain.handle('preload:setCache', (_event, payload) => {
-    const key = typeof payload?.key === 'string' ? payload.key : null
-    const loadedAt = typeof payload?.loadedAt === 'number' ? payload.loadedAt : Date.now()
-    const hash = typeof payload?.hash === 'string' ? payload.hash : undefined
-    const appVersion = typeof payload?.appVersion === 'string' ? payload.appVersion : undefined
-    if (!key) return
-    setPreloadCache(key, { key, loadedAt, hash, appVersion })
-  })
+    const key = typeof payload?.key === 'string' ? payload.key : null;
+    const loadedAt = typeof payload?.loadedAt === 'number' ? payload.loadedAt : Date.now();
+    const hash = typeof payload?.hash === 'string' ? payload.hash : undefined;
+    const appVersion = typeof payload?.appVersion === 'string' ? payload.appVersion : undefined;
+    if (!key) return;
+    setPreloadCache(key, { key, loadedAt, hash, appVersion });
+  });
   ipcMain.handle('vault:readTree', async (_event, payload) => {
-    const result = await readVaultTree(payload ?? {})
+    const result = await readVaultTree(payload ?? {});
     if (payload?.path) {
-      vaultWatcherController.scheduleStart(payload.path)
+      vaultWatcherController.scheduleStart(payload.path);
     }
-    return result
-  })
+    return result;
+  });
   ipcMain.handle('vault:getTreeCache', (_event, payload) => {
-    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : ''
-    if (!vaultPath) return null
-    return getTreeCache(vaultPath)
-  })
+    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : '';
+    if (!vaultPath) return null;
+    return getTreeCache(vaultPath);
+  });
   ipcMain.handle('vault:setTreeCache', (_event, payload) => {
-    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : ''
-    const nodes = Array.isArray(payload?.nodes) ? (payload.nodes as VaultTreeNode[]) : []
-    if (!vaultPath || nodes.length === 0) return
-    setTreeCache(vaultPath, nodes)
-  })
+    const vaultPath = typeof payload?.vaultPath === 'string' ? payload.vaultPath : '';
+    const nodes = Array.isArray(payload?.nodes) ? (payload.nodes as VaultTreeNode[]) : [];
+    if (!vaultPath || nodes.length === 0) return;
+    setTreeCache(vaultPath, nodes);
+  });
   ipcMain.handle('vault:updateWatchPaths', async (_event, payload) => {
-    const paths = Array.isArray(payload?.paths) ? payload.paths : []
-    await vaultWatcherController.updateExpandedWatchers(paths)
-  })
-  ipcMain.handle('preload:getConfig', () => getPreloadConfig())
+    const paths = Array.isArray(payload?.paths) ? payload.paths : [];
+    await vaultWatcherController.updateExpandedWatchers(paths);
+  });
+  ipcMain.handle('preload:getConfig', () => getPreloadConfig());
   ipcMain.handle('preload:setConfig', (_event, payload) => {
     setPreloadConfig({
       disabled: typeof payload?.disabled === 'boolean' ? payload.disabled : undefined,
       ttlMs: typeof payload?.ttlMs === 'number' ? payload.ttlMs : undefined,
-    })
-  })
-  ipcMain.handle('files:read', (_event, payload) => readVaultFile(payload ?? {}))
-  ipcMain.handle('files:write', (_event, payload) => writeVaultFile(payload ?? {}))
-  ipcMain.handle('files:createFile', (_event, payload) => createVaultFile(payload ?? {}))
-  ipcMain.handle('files:createFolder', (_event, payload) => createVaultFolder(payload ?? {}))
-  ipcMain.handle('files:rename', (_event, payload) => renameVaultEntry(payload ?? {}))
-  ipcMain.handle('files:move', (_event, payload) => moveVaultEntry(payload ?? {}))
-  ipcMain.handle('files:delete', (_event, payload) => deleteVaultEntry(payload ?? {}))
-  ipcMain.handle('files:showInFinder', (_event, payload) => showItemInFinder(payload ?? {}))
-  ipcMain.handle('agent:settings:get', () => getAgentSettings())
-  ipcMain.handle('agent:settings:update', (_event, payload) => updateAgentSettings(payload ?? {}))
+    });
+  });
+  ipcMain.handle('files:read', (_event, payload) => readVaultFile(payload ?? {}));
+  ipcMain.handle('files:write', (_event, payload) => writeVaultFile(payload ?? {}));
+  ipcMain.handle('files:createFile', (_event, payload) => createVaultFile(payload ?? {}));
+  ipcMain.handle('files:createFolder', (_event, payload) => createVaultFolder(payload ?? {}));
+  ipcMain.handle('files:rename', (_event, payload) => renameVaultEntry(payload ?? {}));
+  ipcMain.handle('files:move', (_event, payload) => moveVaultEntry(payload ?? {}));
+  ipcMain.handle('files:delete', (_event, payload) => deleteVaultEntry(payload ?? {}));
+  ipcMain.handle('files:showInFinder', (_event, payload) => showItemInFinder(payload ?? {}));
+  ipcMain.handle('agent:settings:get', () => getAgentSettings());
+  ipcMain.handle('agent:settings:update', (_event, payload) => updateAgentSettings(payload ?? {}));
   ipcMain.handle('agent:test-provider', async (_event, payload) => {
-    const { providerId, apiKey, baseUrl, modelId, sdkType } = payload ?? {}
+    const { providerId, apiKey, baseUrl, modelId, sdkType } = payload ?? {};
     if (!apiKey || typeof apiKey !== 'string') {
       return {
         success: false,
         error: 'API Key is required',
-      }
+      };
     }
     if (!providerId || typeof providerId !== 'string') {
       return {
         success: false,
         error: 'Provider ID is required',
-      }
+      };
+    }
+
+    const trimmedModelId = typeof modelId === 'string' ? modelId.trim() : '';
+    if (!trimmedModelId) {
+      return {
+        success: false,
+        error: 'Model ID is required',
+      };
     }
 
     try {
-      const { generateText } = await import('ai')
+      const { generateText } = await import('ai');
 
       // 获取预设服务商信息
-      const preset = getProviderById(providerId)
-      const effectiveSdkType = sdkType || preset?.sdkType || 'openai-compatible'
-      const effectiveBaseUrl = baseUrl?.trim() || preset?.defaultBaseUrl
+      const preset = getProviderById(providerId);
+      const effectiveSdkType = sdkType || preset?.sdkType || 'openai-compatible';
+      const effectiveBaseUrl = baseUrl?.trim() || preset?.defaultBaseUrl;
+      const apiModelId =
+        preset && !providerId.startsWith('custom-')
+          ? toApiModelId(providerId, trimmedModelId)
+          : trimmedModelId;
 
       // 根据 SDK 类型创建模型
-      let model
-      const trimmedApiKey = apiKey.trim()
+      let model;
+      const trimmedApiKey = apiKey.trim();
 
       switch (effectiveSdkType) {
         case 'openai': {
-          const { createOpenAI } = await import('@ai-sdk/openai')
-          const client = createOpenAI({ apiKey: trimmedApiKey, baseURL: effectiveBaseUrl })
-          model = client.chat(modelId?.trim() || 'gpt-4o-mini')
-          break
+          const { createOpenAI } = await import('@ai-sdk/openai');
+          const client = createOpenAI({ apiKey: trimmedApiKey, baseURL: effectiveBaseUrl });
+          model = client.chat(apiModelId);
+          break;
         }
         case 'anthropic': {
-          const { createAnthropic } = await import('@ai-sdk/anthropic')
-          const client = createAnthropic({ apiKey: trimmedApiKey, baseURL: effectiveBaseUrl })
-          model = client.chat(modelId?.trim() || 'claude-3-5-sonnet-20241022')
-          break
+          const { createAnthropic } = await import('@ai-sdk/anthropic');
+          const client = createAnthropic({ apiKey: trimmedApiKey, baseURL: effectiveBaseUrl });
+          model = client.chat(apiModelId);
+          break;
         }
         case 'google': {
-          const { createGoogleGenerativeAI } = await import('@ai-sdk/google')
-          const client = createGoogleGenerativeAI({ apiKey: trimmedApiKey, baseURL: effectiveBaseUrl })
-          model = client(modelId?.trim() || 'gemini-1.5-flash')
-          break
+          const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
+          const client = createGoogleGenerativeAI({
+            apiKey: trimmedApiKey,
+            baseURL: effectiveBaseUrl,
+          });
+          model = client(apiModelId);
+          break;
         }
         case 'xai': {
-          const { createXai } = await import('@ai-sdk/xai')
-          const client = createXai({ apiKey: trimmedApiKey, baseURL: effectiveBaseUrl })
-          model = client.chat(modelId?.trim() || 'grok-2-1212')
-          break
+          const { createXai } = await import('@ai-sdk/xai');
+          const client = createXai({ apiKey: trimmedApiKey, baseURL: effectiveBaseUrl });
+          model = client.chat(apiModelId);
+          break;
         }
         case 'openrouter': {
-          const { createOpenRouter } = await import('@openrouter/ai-sdk-provider')
+          const { createOpenRouter } = await import('@openrouter/ai-sdk-provider');
           const client = createOpenRouter({
             apiKey: trimmedApiKey,
             baseURL: effectiveBaseUrl,
             headers: { 'X-Title': 'Moryflow', 'HTTP-Referer': 'https://moryflow.com/' },
-          })
-          model = client.chat(modelId?.trim() || 'openai/gpt-4o-mini')
-          break
+          });
+          model = client.chat(apiModelId);
+          break;
         }
         case 'openai-compatible':
         default: {
-          const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible')
+          const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
           const client = createOpenAICompatible({
             name: providerId,
             apiKey: trimmedApiKey,
             baseURL: effectiveBaseUrl || 'https://api.openai.com/v1',
-          })
-          model = client(modelId?.trim() || 'gpt-4o-mini')
-          break
+          });
+          model = client(apiModelId);
+          break;
         }
       }
 
       const result = await generateText({
         model,
         prompt: 'Say "Test successful" and nothing else.',
-      })
+      });
 
       return {
         success: true,
-        message: result.text || '连接成功',
-      }
+        message: result.text || 'Connection successful.',
+      };
     } catch (error) {
-      console.error('[test-provider] test failed:', error)
+      console.error('[test-provider] test failed:', error);
       return {
         success: false,
         error: error instanceof Error ? error.message : String(error),
-      }
+      };
     }
-  })
-  ipcMain.handle('app:resetApp', () => resetApp())
+  });
+  ipcMain.handle('app:resetApp', () => resetApp());
 
   // MCP 状态相关
   ipcMain.handle('agent:mcp:getStatus', () => {
-    return getRuntime().getMcpStatus()
-  })
+    return getRuntime().getMcpStatus();
+  });
 
   ipcMain.handle('agent:mcp:testServer', (_event, payload) => {
-    return getRuntime().testMcpServer(payload)
-  })
+    return getRuntime().testMcpServer(payload);
+  });
 
   ipcMain.handle('agent:mcp:reload', () => {
-    getRuntime().reloadMcp()
-  })
+    getRuntime().reloadMcp();
+  });
 
   // MCP 状态变更事件广播到所有窗口
-  const runtime = getRuntime()
+  const runtime = getRuntime();
   runtime.onMcpStatusChange((event) => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('agent:mcp-status-changed', event)
+      win.webContents.send('agent:mcp-status-changed', event);
     }
-  })
+  });
 
   // Ollama 相关
   ipcMain.handle('ollama:checkConnection', async (_event, payload) => {
-    const baseUrl = typeof payload?.baseUrl === 'string' ? payload.baseUrl : undefined
-    return ollamaService.checkConnection(baseUrl)
-  })
+    const baseUrl = typeof payload?.baseUrl === 'string' ? payload.baseUrl : undefined;
+    return ollamaService.checkConnection(baseUrl);
+  });
 
   ipcMain.handle('ollama:getLocalModels', async (_event, payload) => {
-    const baseUrl = typeof payload?.baseUrl === 'string' ? payload.baseUrl : undefined
+    const baseUrl = typeof payload?.baseUrl === 'string' ? payload.baseUrl : undefined;
     try {
-      return await ollamaService.getLocalModels(baseUrl)
+      return await ollamaService.getLocalModels(baseUrl);
     } catch (error) {
-      console.error('[ollama:getLocalModels] error:', error)
-      return []
+      console.error('[ollama:getLocalModels] error:', error);
+      return [];
     }
-  })
+  });
 
   ipcMain.handle('ollama:getLibraryModels', async (_event, payload) => {
     try {
       return await ollamaService.getLibraryModels({
         search: typeof payload?.search === 'string' ? payload.search : undefined,
         capability: typeof payload?.capability === 'string' ? payload.capability : undefined,
-        sortBy: payload?.sortBy === 'pulls' || payload?.sortBy === 'last_updated' ? payload.sortBy : undefined,
+        sortBy:
+          payload?.sortBy === 'pulls' || payload?.sortBy === 'last_updated'
+            ? payload.sortBy
+            : undefined,
         order: payload?.order === 'asc' || payload?.order === 'desc' ? payload.order : undefined,
         limit: typeof payload?.limit === 'number' ? payload.limit : undefined,
-      })
+      });
     } catch (error) {
-      console.error('[ollama:getLibraryModels] error:', error)
-      return []
+      console.error('[ollama:getLibraryModels] error:', error);
+      return [];
     }
-  })
+  });
 
   ipcMain.handle('ollama:pullModel', async (_event, payload) => {
-    const name = typeof payload?.name === 'string' ? payload.name : ''
-    const baseUrl = typeof payload?.baseUrl === 'string' ? payload.baseUrl : undefined
+    const name = typeof payload?.name === 'string' ? payload.name : '';
+    const baseUrl = typeof payload?.baseUrl === 'string' ? payload.baseUrl : undefined;
 
     if (!name) {
-      return { success: false, error: 'Model name is required' }
+      return { success: false, error: 'Model name is required' };
     }
 
     try {
@@ -399,99 +432,103 @@ export const registerIpcHandlers = ({ vaultWatcherController }: RegisterIpcHandl
               digest: progress.digest,
               total: progress.total,
               completed: progress.completed,
-            })
+            });
           }
         },
         baseUrl
-      )
-      return { success: true }
+      );
+      return { success: true };
     } catch (error) {
-      console.error('[ollama:pullModel] error:', error)
-      return { success: false, error: error instanceof Error ? error.message : String(error) }
+      console.error('[ollama:pullModel] error:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
-  })
+  });
 
   ipcMain.handle('ollama:deleteModel', async (_event, payload) => {
-    const name = typeof payload?.name === 'string' ? payload.name : ''
-    const baseUrl = typeof payload?.baseUrl === 'string' ? payload.baseUrl : undefined
+    const name = typeof payload?.name === 'string' ? payload.name : '';
+    const baseUrl = typeof payload?.baseUrl === 'string' ? payload.baseUrl : undefined;
 
     if (!name) {
-      return { success: false, error: 'Model name is required' }
+      return { success: false, error: 'Model name is required' };
     }
 
     try {
-      await ollamaService.deleteModel(name, baseUrl)
-      return { success: true }
+      await ollamaService.deleteModel(name, baseUrl);
+      return { success: true };
     } catch (error) {
-      console.error('[ollama:deleteModel] error:', error)
-      return { success: false, error: error instanceof Error ? error.message : String(error) }
+      console.error('[ollama:deleteModel] error:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
-  })
+  });
 
   // ── Membership ──────────────────────────────────────────────
   ipcMain.handle('membership:syncToken', (_event, payload) => {
-    const token = payload === null ? null : typeof payload === 'string' ? payload : null
-    membershipBridge.syncToken(token)
-  })
+    const token = payload === null ? null : typeof payload === 'string' ? payload : null;
+    membershipBridge.syncToken(token);
+  });
 
   ipcMain.handle('membership:syncEnabled', (_event, payload) => {
-    const enabled = typeof payload === 'boolean' ? payload : true
-    membershipBridge.setEnabled(enabled)
-  })
+    const enabled = typeof payload === 'boolean' ? payload : true;
+    membershipBridge.setEnabled(enabled);
+  });
 
   // ── Cloud Sync ────────────────────────────────────────────────
 
-  ipcMain.handle('cloud-sync:getSettings', () => readSettings())
+  ipcMain.handle('cloud-sync:getSettings', () => readSettings());
 
   ipcMain.handle('cloud-sync:updateSettings', (_event, payload) => {
-    const current = readSettings()
-    const next = { ...current, ...payload }
-    writeSettings(next)
-    return next
-  })
+    const current = readSettings();
+    const next = { ...current, ...payload };
+    writeSettings(next);
+    return next;
+  });
 
   ipcMain.handle('cloud-sync:getBinding', (_event, payload) => {
-    const localPath = typeof payload?.localPath === 'string' ? payload.localPath : ''
-    if (!localPath) return null
-    return readBinding(localPath)
-  })
+    const localPath = typeof payload?.localPath === 'string' ? payload.localPath : '';
+    if (!localPath) return null;
+    return readBinding(localPath);
+  });
 
   ipcMain.handle('cloud-sync:bindVault', async (_event, payload) => {
-    const localPath = typeof payload?.localPath === 'string' ? payload.localPath : ''
-    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : undefined
-    const vaultName = typeof payload?.vaultName === 'string' ? payload.vaultName : undefined
+    const localPath = typeof payload?.localPath === 'string' ? payload.localPath : '';
+    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : undefined;
+    const vaultName = typeof payload?.vaultName === 'string' ? payload.vaultName : undefined;
 
     if (!localPath) {
-      throw new Error('localPath is required')
+      throw new Error('localPath is required');
     }
 
-    const settings = readSettings()
-    let finalVaultId = vaultId
-    let finalVaultName = vaultName || path.basename(localPath)
+    const settings = readSettings();
+    let finalVaultId = vaultId;
+    let finalVaultName = vaultName || path.basename(localPath);
 
     // 获取当前用户 ID
-    const userId = await fetchCurrentUserId()
+    const userId = await fetchCurrentUserId();
     if (!userId) {
-      throw new Error('Cannot determine current user ID')
+      throw new Error('Cannot determine current user ID');
     }
 
     try {
       // 如果没有指定 vaultId，创建新的
       if (!finalVaultId) {
-        console.log('[cloud-sync:bindVault] creating vault:', finalVaultName)
-        const vault = await cloudSyncApi.createVault(finalVaultName)
-        finalVaultId = vault.id
-        finalVaultName = vault.name
-        console.log('[cloud-sync:bindVault] vault created:', finalVaultId)
+        console.log('[cloud-sync:bindVault] creating vault:', finalVaultName);
+        const vault = await cloudSyncApi.createVault(finalVaultName);
+        finalVaultId = vault.id;
+        finalVaultName = vault.name;
+        console.log('[cloud-sync:bindVault] vault created:', finalVaultId);
       }
 
       // 注册设备
-      console.log('[cloud-sync:bindVault] registering device:', settings.deviceId, settings.deviceName)
-      await cloudSyncApi.registerDevice(finalVaultId, settings.deviceId, settings.deviceName)
-      console.log('[cloud-sync:bindVault] device registered')
+      console.log(
+        '[cloud-sync:bindVault] registering device:',
+        settings.deviceId,
+        settings.deviceName
+      );
+      await cloudSyncApi.registerDevice(finalVaultId, settings.deviceId, settings.deviceName);
+      console.log('[cloud-sync:bindVault] device registered');
     } catch (error) {
-      console.error('[cloud-sync:bindVault] API error:', error)
-      throw error
+      console.error('[cloud-sync:bindVault] API error:', error);
+      throw error;
     }
 
     // 保存绑定
@@ -501,114 +538,114 @@ export const registerIpcHandlers = ({ vaultWatcherController }: RegisterIpcHandl
       vaultName: finalVaultName,
       boundAt: Date.now(),
       userId,
-    }
-    writeBinding(binding)
+    };
+    writeBinding(binding);
 
     // 诊断日志：验证绑定是否正确保存
-    const readBack = readBinding(localPath)
+    const readBack = readBinding(localPath);
     console.log('[cloud-sync:bindVault] saved:', {
       localPath,
       binding,
       readBack: readBack ? { vaultId: readBack.vaultId, vaultName: readBack.vaultName } : null,
-    })
+    });
 
     // 重新初始化同步引擎
-    await cloudSyncEngine.reinit()
+    await cloudSyncEngine.reinit();
 
-    return binding
-  })
+    return binding;
+  });
 
   ipcMain.handle('cloud-sync:unbindVault', (_event, payload) => {
-    const localPath = typeof payload?.localPath === 'string' ? payload.localPath : ''
-    if (!localPath) return
-    deleteBinding(localPath)
-    cloudSyncEngine.stop()
-  })
+    const localPath = typeof payload?.localPath === 'string' ? payload.localPath : '';
+    if (!localPath) return;
+    deleteBinding(localPath);
+    cloudSyncEngine.stop();
+  });
 
   ipcMain.handle('cloud-sync:listCloudVaults', async () => {
     try {
-      const { vaults } = await cloudSyncApi.listVaults()
+      const { vaults } = await cloudSyncApi.listVaults();
       return vaults.map((v) => ({
         id: v.id,
         name: v.name,
         fileCount: v.fileCount,
         deviceCount: v.deviceCount,
-      }))
+      }));
     } catch (error) {
-      console.error('[cloud-sync:listCloudVaults] error:', error)
-      return []
+      console.error('[cloud-sync:listCloudVaults] error:', error);
+      return [];
     }
-  })
+  });
 
-  ipcMain.handle('cloud-sync:getStatus', () => cloudSyncEngine.getStatus())
+  ipcMain.handle('cloud-sync:getStatus', () => cloudSyncEngine.getStatus());
 
-  ipcMain.handle('cloud-sync:getStatusDetail', () => cloudSyncEngine.getStatusDetail())
+  ipcMain.handle('cloud-sync:getStatusDetail', () => cloudSyncEngine.getStatusDetail());
 
   ipcMain.handle('cloud-sync:triggerSync', () => {
-    cloudSyncEngine.triggerSync()
-  })
+    cloudSyncEngine.triggerSync();
+  });
 
   ipcMain.handle('cloud-sync:getUsage', async () => {
     try {
-      const result = await cloudSyncApi.getUsage()
+      const result = await cloudSyncApi.getUsage();
       // 诊断日志：显示用量查询结果
       console.log('[cloud-sync:getUsage] success:', {
         storage: result.storage,
         vectorized: result.vectorized,
         plan: result.plan,
-      })
-      return result
+      });
+      return result;
     } catch (error) {
       // 诊断日志：详细记录错误信息
       console.error('[cloud-sync:getUsage] API failed:', {
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
-      })
+      });
       return {
         storage: { used: 0, limit: 0, percentage: 0 },
         vectorized: { count: 0, limit: 0, percentage: 0 },
         fileLimit: { maxFileSize: 0 },
         plan: 'unknown',
-      }
+      };
     }
-  })
+  });
 
   ipcMain.handle('cloud-sync:search', async (_event, payload) => {
-    const query = typeof payload?.query === 'string' ? payload.query : ''
-    const topK = typeof payload?.topK === 'number' ? payload.topK : undefined
-    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : undefined
+    const query = typeof payload?.query === 'string' ? payload.query : '';
+    const topK = typeof payload?.topK === 'number' ? payload.topK : undefined;
+    const vaultId = typeof payload?.vaultId === 'string' ? payload.vaultId : undefined;
 
-    if (!query) return []
+    if (!query) return [];
 
     try {
-      const response = await cloudSyncApi.search({ query, topK, vaultId })
-      const status = cloudSyncEngine.getStatus()
+      const response = await cloudSyncApi.search({ query, topK, vaultId });
+      const status = cloudSyncEngine.getStatus();
 
       // 填充 localPath
       if (status.vaultPath) {
         const results = response.results.map((r) => ({
           ...r,
           localPath: fileIndexManager.getByFileId(status.vaultPath!, r.fileId) ?? undefined,
-        }))
-        return results
+        }));
+        return results;
       }
 
-      return response.results
+      return response.results;
     } catch (error) {
-      console.error('[cloud-sync:search] error:', error)
-      return []
+      console.error('[cloud-sync:search] error:', error);
+      return [];
     }
-  })
+  });
 
   // 绑定冲突响应处理
   ipcMain.handle('cloud-sync:binding-conflict-response', (_event, payload) => {
-    const requestId = typeof payload?.requestId === 'string' ? payload.requestId : ''
+    const requestId = typeof payload?.requestId === 'string' ? payload.requestId : '';
     const choice =
       payload?.choice === 'sync_to_current' || payload?.choice === 'stay_offline'
         ? payload.choice
-        : 'stay_offline'
+        : 'stay_offline';
     if (requestId) {
-      handleBindingConflictResponse(requestId, choice)
+      handleBindingConflictResponse(requestId, choice);
     }
-  })
-}
+  });
+};

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/add-custom-provider-model-dialog.tsx
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/add-custom-provider-model-dialog.tsx
@@ -1,0 +1,148 @@
+/**
+ * [PROPS]: { open, onOpenChange, existingModelIds, onAdd }
+ * [EMITS]: onAdd({ id, name }) - 添加自定义服务商模型条目（enabled 默认 true 由上层决定）
+ * [POS]: Custom Provider 的模型录入弹窗（只负责收集 id/name，校验与提交）
+ *
+ * [PROTOCOL]: 本文件变更时，必须更新此 Header 及所属目录 CLAUDE.md
+ */
+
+import { useEffect, useMemo } from 'react';
+import { z } from 'zod/v3';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@anyhunt/ui/components/dialog';
+import { Label } from '@anyhunt/ui/components/label';
+import { Input } from '@anyhunt/ui/components/input';
+import { Button } from '@anyhunt/ui/components/button';
+
+type AddCustomProviderModelDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingModelIds: string[];
+  onAdd: (data: { id: string; name: string }) => void;
+};
+
+export const AddCustomProviderModelDialog = ({
+  open,
+  onOpenChange,
+  existingModelIds,
+  onAdd,
+}: AddCustomProviderModelDialogProps) => {
+  const schema = useMemo(() => {
+    return z
+      .object({
+        id: z.string().min(1, 'Model ID is required'),
+        name: z.string().min(1, 'Model name is required'),
+      })
+      .superRefine((value, ctx) => {
+        const id = value.id.trim();
+        const name = value.name.trim();
+        if (!id) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['id'],
+            message: 'Model ID is required',
+          });
+          return;
+        }
+        if (!name) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['name'],
+            message: 'Model name is required',
+          });
+        }
+        if (existingModelIds.includes(id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['id'],
+            message: 'Model ID already exists',
+          });
+        }
+      });
+  }, [existingModelIds]);
+
+  type FormValues = z.infer<typeof schema>;
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { id: '', name: '' },
+    mode: 'onSubmit',
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = form;
+
+  useEffect(() => {
+    if (!open) {
+      reset({ id: '', name: '' });
+    }
+  }, [open, reset]);
+
+  const submit = handleSubmit((values) => {
+    const id = values.id.trim();
+    const name = values.name.trim();
+    onAdd({ id, name });
+    reset({ id: '', name: '' });
+    onOpenChange(false);
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[460px]">
+        <DialogHeader>
+          <DialogTitle>Add model</DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void submit();
+          }}
+          className="grid gap-4 py-2"
+        >
+          <div className="space-y-2">
+            <Label htmlFor="custom-model-id">
+              Model ID <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="custom-model-id"
+              placeholder="e.g. gpt-4o, claude-3-5-sonnet, o4-mini"
+              {...register('id')}
+            />
+            {errors.id?.message && <p className="text-xs text-destructive">{errors.id.message}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="custom-model-name">
+              Model name <span className="text-destructive">*</span>
+            </Label>
+            <Input id="custom-model-name" placeholder="Display name" {...register('name')} />
+            {errors.name?.message && (
+              <p className="text-xs text-destructive">{errors.name.message}</p>
+            )}
+          </div>
+
+          <DialogFooter className="mt-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Add
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/custom-provider-models.tsx
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/custom-provider-models.tsx
@@ -1,0 +1,97 @@
+/**
+ * [PROPS]: { models, onAddModel, onToggleModel, onDeleteModel }
+ * [EMITS]: onAddModel({ id, name }), onToggleModel(modelId, enabled), onDeleteModel(modelId)
+ * [POS]: Custom Provider 的模型列表 UI（不直接读写表单，仅负责展示和交互）
+ *
+ * [PROTOCOL]: 本文件变更时，必须更新此 Header 及所属目录 CLAUDE.md
+ */
+
+import { useMemo, useState } from 'react';
+import { Button } from '@anyhunt/ui/components/button';
+import { Label } from '@anyhunt/ui/components/label';
+import { Switch } from '@anyhunt/ui/components/switch';
+import { Plus, Trash2 } from 'lucide-react';
+import { AddCustomProviderModelDialog } from './add-custom-provider-model-dialog';
+
+export type CustomProviderModel = {
+  id: string;
+  name: string;
+  enabled: boolean;
+};
+
+type CustomProviderModelsProps = {
+  models: CustomProviderModel[];
+  onAddModel: (data: { id: string; name: string }) => void;
+  onToggleModel: (modelId: string, enabled: boolean) => void;
+  onDeleteModel: (modelId: string) => void;
+};
+
+export const CustomProviderModels = ({
+  models,
+  onAddModel,
+  onToggleModel,
+  onDeleteModel,
+}: CustomProviderModelsProps) => {
+  const [addOpen, setAddOpen] = useState(false);
+
+  const existingModelIds = useMemo(() => models.map((m) => m.id), [models]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Label>Models</Label>
+        <Button type="button" variant="outline" size="icon" onClick={() => setAddOpen(true)}>
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        {models.length === 0 ? (
+          <div className="text-sm text-muted-foreground">
+            No models yet. Add one to enable testing and model selection.
+          </div>
+        ) : (
+          models.map((model) => (
+            <div
+              key={model.id}
+              className="flex items-center justify-between py-2 px-3 rounded-md border"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium truncate">{model.name}</span>
+                </div>
+                <div className="text-xs text-muted-foreground font-mono truncate">{model.id}</div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => {
+                    const ok = window.confirm(`Delete model "${model.name}"?`);
+                    if (ok) onDeleteModel(model.id);
+                  }}
+                  aria-label="Delete model"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+                <Switch
+                  checked={model.enabled}
+                  onCheckedChange={(checked) => onToggleModel(model.id, checked)}
+                />
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <AddCustomProviderModelDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        existingModelIds={existingModelIds}
+        onAdd={onAddModel}
+      />
+    </div>
+  );
+};

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-details.tsx
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-details.tsx
@@ -1,32 +1,48 @@
-import { useState, useMemo, useCallback, useEffect } from 'react'
-import { Input } from '@anyhunt/ui/components/input'
-import { Label } from '@anyhunt/ui/components/label'
-import { Button } from '@anyhunt/ui/components/button'
-import { Switch } from '@anyhunt/ui/components/switch'
-import { Badge } from '@anyhunt/ui/components/badge'
-import { ScrollArea } from '@anyhunt/ui/components/scroll-area'
+/**
+ * [PROPS]: { providers, form }
+ * [EMITS]: 通过 react-hook-form setValue 修改 settings 表单；通过 desktopAPI 触发 provider 测试
+ * [POS]: 设置弹窗 - AI Providers 详情页（预设/自定义服务商配置、模型启用与连接测试）
+ *
+ * [PROTOCOL]: 本文件变更时，必须更新此 Header 及所属目录 CLAUDE.md
+ */
+
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { Input } from '@anyhunt/ui/components/input';
+import { Label } from '@anyhunt/ui/components/label';
+import { Button } from '@anyhunt/ui/components/button';
+import { Switch } from '@anyhunt/ui/components/switch';
+import { Badge } from '@anyhunt/ui/components/badge';
+import { ScrollArea } from '@anyhunt/ui/components/scroll-area';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@anyhunt/ui/components/select'
-import { ExternalLink, Trash2, Check, Loader2, Search, Plus, Settings2 } from 'lucide-react'
-import { getProviderById, modelRegistry } from '@shared/model-registry'
-import type { SettingsDialogState } from '../../use-settings-dialog'
-import type { ProviderSdkType } from '@shared/ipc'
-import { AddModelDialog, type AddModelFormData } from './add-model-dialog'
-import { EditModelDialog, type EditModelFormData, type EditModelInitialData } from './edit-model-dialog'
-import { OllamaPanel } from './ollama-panel'
-import { MembershipDetails } from './membership-details'
-import { MEMBERSHIP_PROVIDER_ID } from './provider-list'
-import { useTranslation } from '@/lib/i18n'
+} from '@anyhunt/ui/components/select';
+import { ExternalLink, Trash2, Check, Loader2, Search, Plus, Settings2 } from 'lucide-react';
+import { getProviderById, modelRegistry } from '@shared/model-registry';
+import type { SettingsDialogState } from '../../use-settings-dialog';
+import type { AgentProviderTestInput, ProviderSdkType } from '@shared/ipc';
+import { AddModelDialog, type AddModelFormData } from './add-model-dialog';
+import {
+  EditModelDialog,
+  type EditModelFormData,
+  type EditModelInitialData,
+} from './edit-model-dialog';
+import { OllamaPanel } from './ollama-panel';
+import { MembershipDetails } from './membership-details';
+import { MEMBERSHIP_PROVIDER_ID } from './provider-list';
+import { useTranslation } from '@/lib/i18n';
+import { toast } from 'sonner';
+import { CustomProviderModels } from './custom-provider-models';
+import { findFirstEnabledModelId, isModelEnabledWithDefaultFirst } from './provider-models';
+import { ProviderEnabledToggle } from './provider-enabled-toggle';
 
 type ProviderDetailsProps = {
-  providers: SettingsDialogState['providers']
-  form: SettingsDialogState['form']
-}
+  providers: SettingsDialogState['providers'];
+  form: SettingsDialogState['form'];
+};
 
 const SDK_TYPE_OPTIONS = [
   { value: 'openai', labelKey: 'OpenAI' },
@@ -35,56 +51,62 @@ const SDK_TYPE_OPTIONS = [
   { value: 'xai', labelKey: 'xAI' },
   { value: 'openrouter', labelKey: 'OpenRouter' },
   { value: 'openai-compatible', labelKey: 'sdkTypeOpenAICompatible' },
-] as const satisfies readonly { value: ProviderSdkType; labelKey: string }[]
+] as const satisfies readonly { value: ProviderSdkType; labelKey: string }[];
 
 /**
  * 服务商详情面板
  * 显示选中服务商的配置表单
  */
 export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
-  const { t } = useTranslation('settings')
+  const { t } = useTranslation('settings');
   const { activeProviderId, providerValues, customProviderValues, handleRemoveCustomProvider } =
-    providers
-  const { setValue, getValues, register } = form
+    providers;
+  const { setValue, getValues, register } = form;
 
   // 所有 hooks 必须在组件顶层调用（不能在条件语句之后）
-  const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [addModelOpen, setAddModelOpen] = useState(false)
-  const [editModelOpen, setEditModelOpen] = useState(false)
-  const [editModelData, setEditModelData] = useState<EditModelInitialData | null>(null)
+  const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const testStatusResetTimeoutRef = useRef<number | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [addModelOpen, setAddModelOpen] = useState(false);
+  const [editModelOpen, setEditModelOpen] = useState(false);
+  const [editModelData, setEditModelData] = useState<EditModelInitialData | null>(null);
 
   // 判断是预设服务商还是自定义服务商
-  const isMembership = activeProviderId === MEMBERSHIP_PROVIDER_ID
-  const isCustom = activeProviderId?.startsWith('custom-') ?? false
-  const preset = !isCustom && activeProviderId ? getProviderById(activeProviderId) : null
+  const isMembership = activeProviderId === MEMBERSHIP_PROVIDER_ID;
+  const isCustom = activeProviderId?.startsWith('custom-') ?? false;
+  const preset = !isCustom && activeProviderId ? getProviderById(activeProviderId) : null;
 
   // 获取配置索引
-  const presetIndex = providerValues.findIndex((p) => p.providerId === activeProviderId)
-  const customIndex = customProviderValues.findIndex((p) => p.providerId === activeProviderId)
+  const presetIndex = providerValues.findIndex((p) => p.providerId === activeProviderId);
+  const customIndex = customProviderValues.findIndex((p) => p.providerId === activeProviderId);
 
   // 获取当前配置
-  const currentConfig = presetIndex >= 0 ? providerValues[presetIndex] : null
-  const userModels = currentConfig?.models || []
+  const currentConfig = presetIndex >= 0 ? providerValues[presetIndex] : null;
+  const userModels = currentConfig?.models || [];
 
   // 构建模型列表（用户添加的模型在前 + 预设模型在后）- hooks 必须在顶层
   const allModels = useMemo(() => {
-    if (!preset) return []
+    if (!preset) return [];
 
     const models: Array<{
-      id: string
-      name: string
-      shortName?: string
-      isPreset: boolean
-      isCustom?: boolean
-      capabilities?: { reasoning: boolean; attachment: boolean; toolCall?: boolean; temperature?: boolean }
-      limits: { context: number; output: number }
-    }> = []
+      id: string;
+      name: string;
+      shortName?: string;
+      isPreset: boolean;
+      isCustom?: boolean;
+      capabilities?: {
+        reasoning: boolean;
+        attachment: boolean;
+        toolCall?: boolean;
+        temperature?: boolean;
+      };
+      limits: { context: number; output: number };
+    }> = [];
 
     // 用户添加的自定义模型（显示在最上面，最新添加的在最前）
-    const customModels = userModels.filter((m) => m.isCustom)
+    const customModels = userModels.filter((m) => m.isCustom);
     for (let i = customModels.length - 1; i >= 0; i--) {
-      const userModel = customModels[i]
+      const userModel = customModels[i];
       models.push({
         id: userModel.id,
         name: userModel.customName || userModel.id,
@@ -102,17 +124,19 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
           context: userModel.customContext || 128000,
           output: userModel.customOutput || 16384,
         },
-      })
+      });
     }
 
     // 预设模型（检查是否有用户自定义配置）
     for (const modelId of preset.modelIds) {
-      const modelDef = modelRegistry[modelId]
+      const modelDef = modelRegistry[modelId];
       if (modelDef) {
         // 检查用户是否自定义了该预设模型（预设模型配置 isCustom 为 false 或 undefined）
-        const userConfig = userModels.find((m) => m.id === modelId && !m.isCustom)
-        const hasCustomName = userConfig?.customName
-        const hasCustomConfig = userConfig && (userConfig.customName || userConfig.customContext || userConfig.customCapabilities)
+        const userConfig = userModels.find((m) => m.id === modelId && !m.isCustom);
+        const hasCustomName = userConfig?.customName;
+        const hasCustomConfig =
+          userConfig &&
+          (userConfig.customName || userConfig.customContext || userConfig.customCapabilities);
 
         models.push({
           id: modelId,
@@ -120,54 +144,57 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
           name: hasCustomName && userConfig.customName ? userConfig.customName : modelDef.name,
           shortName: hasCustomName ? undefined : modelDef.shortName,
           isPreset: true,
-          capabilities: hasCustomConfig && userConfig.customCapabilities
-            ? {
-                reasoning: userConfig.customCapabilities.reasoning ?? modelDef.capabilities.reasoning,
-                attachment: userConfig.customCapabilities.attachment ?? modelDef.capabilities.attachment,
-                toolCall: userConfig.customCapabilities.toolCall ?? modelDef.capabilities.toolCall,
-                temperature: userConfig.customCapabilities.temperature ?? modelDef.capabilities.temperature,
-              }
-            : modelDef.capabilities,
+          capabilities:
+            hasCustomConfig && userConfig.customCapabilities
+              ? {
+                  reasoning:
+                    userConfig.customCapabilities.reasoning ?? modelDef.capabilities.reasoning,
+                  attachment:
+                    userConfig.customCapabilities.attachment ?? modelDef.capabilities.attachment,
+                  toolCall:
+                    userConfig.customCapabilities.toolCall ?? modelDef.capabilities.toolCall,
+                  temperature:
+                    userConfig.customCapabilities.temperature ?? modelDef.capabilities.temperature,
+                }
+              : modelDef.capabilities,
           limits: hasCustomConfig
             ? {
                 context: userConfig.customContext || modelDef.limits.context,
                 output: userConfig.customOutput || modelDef.limits.output,
               }
             : modelDef.limits,
-        })
+        });
       }
     }
 
-    return models
-  }, [preset, userModels])
+    return models;
+  }, [preset, userModels]);
 
   // 搜索过滤
   const filteredModels = useMemo(() => {
-    if (!searchQuery.trim()) return allModels
-    const query = searchQuery.toLowerCase()
-    return allModels.filter(
-      (m) =>
+    const modelsWithIndex = allModels.map((model, index) => ({ model, index }));
+    if (!searchQuery.trim()) return modelsWithIndex;
+    const query = searchQuery.toLowerCase();
+    return modelsWithIndex.filter(
+      ({ model: m }) =>
         m.id.toLowerCase().includes(query) ||
         m.name.toLowerCase().includes(query) ||
         m.shortName?.toLowerCase().includes(query)
-    )
-  }, [allModels, searchQuery])
+    );
+  }, [allModels, searchQuery]);
 
   // 获取所有已配置的模型 ID
   const existingModelIds = useMemo(() => {
-    if (!preset) return []
-    return [
-      ...preset.modelIds,
-      ...userModels.filter((m) => m.isCustom).map((m) => m.id),
-    ]
-  }, [preset, userModels])
+    if (!preset) return [];
+    return [...preset.modelIds, ...userModels.filter((m) => m.isCustom).map((m) => m.id)];
+  }, [preset, userModels]);
 
   // 确保预设服务商有配置记录（在 useEffect 中调用，避免渲染期间 setState）
   useEffect(() => {
     if (!isCustom && activeProviderId && preset) {
       // 使用 getValues 获取最新值，避免闭包问题和重复添加
-      const currentProviders = getValues('providers')
-      const existingIndex = currentProviders.findIndex((p) => p.providerId === activeProviderId)
+      const currentProviders = getValues('providers');
+      const existingIndex = currentProviders.findIndex((p) => p.providerId === activeProviderId);
       if (existingIndex < 0) {
         setValue('providers', [
           ...currentProviders,
@@ -179,113 +206,305 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
             models: [],
             defaultModelId: null,
           },
-        ])
+        ]);
       }
     }
-  }, [isCustom, activeProviderId, getValues, setValue, preset])
+  }, [isCustom, activeProviderId, getValues, setValue, preset]);
 
+  // 避免 setTimeout 在组件卸载后触发 setState
+  useEffect(() => {
+    return () => {
+      if (testStatusResetTimeoutRef.current) {
+        window.clearTimeout(testStatusResetTimeoutRef.current);
+        testStatusResetTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  const scheduleTestStatusReset = useCallback(() => {
+    if (testStatusResetTimeoutRef.current) {
+      window.clearTimeout(testStatusResetTimeoutRef.current);
+    }
+    testStatusResetTimeoutRef.current = window.setTimeout(() => {
+      setTestStatus('idle');
+      testStatusResetTimeoutRef.current = null;
+    }, 3000);
+  }, []);
+
+  // API Key 从空 -> 非空时，自动开启服务商（防止“填完忘了开”）
+  const lastTrimmedApiKeyByProviderIdRef = useRef<Record<string, string>>({});
+  useEffect(() => {
+    if (!activeProviderId) return;
+
+    const apiKey = isCustom
+      ? (customProviderValues[customIndex]?.apiKey ?? '')
+      : (providerValues[presetIndex]?.apiKey ?? '');
+
+    const trimmed = apiKey.trim();
+    const prev = lastTrimmedApiKeyByProviderIdRef.current[activeProviderId] ?? '';
+
+    if (!prev && trimmed) {
+      if (isCustom && customIndex >= 0) {
+        setValue(`customProviders.${customIndex}.enabled`, true);
+      }
+      if (!isCustom && presetIndex >= 0) {
+        setValue(`providers.${presetIndex}.enabled`, true);
+      }
+    }
+
+    lastTrimmedApiKeyByProviderIdRef.current[activeProviderId] = trimmed;
+  }, [
+    activeProviderId,
+    isCustom,
+    customIndex,
+    presetIndex,
+    customProviderValues,
+    providerValues,
+    setValue,
+  ]);
 
   // 测试连接
   const handleTest = useCallback(async () => {
-    setTestStatus('testing')
+    // 多次点击时避免旧定时器影响状态
+    if (testStatusResetTimeoutRef.current) {
+      window.clearTimeout(testStatusResetTimeoutRef.current);
+      testStatusResetTimeoutRef.current = null;
+    }
+
+    setTestStatus('testing');
     try {
-      const config = isCustom ? customProviderValues[customIndex] : providerValues[presetIndex]
-      if (!config?.apiKey) {
-        setTestStatus('error')
-        return
+      if (!activeProviderId) {
+        toast.error('Provider is required.');
+        setTestStatus('error');
+        scheduleTestStatusReset();
+        return;
+      }
+      if (!window.desktopAPI?.testAgentProvider) {
+        toast.error('Desktop API is unavailable.');
+        setTestStatus('error');
+        scheduleTestStatusReset();
+        return;
       }
 
-      const result = await window.desktopAPI?.testAgentProvider?.({
-        providerId: activeProviderId!,
-        apiKey: config.apiKey,
-        baseUrl: config.baseUrl || undefined,
-        modelId: config.defaultModelId || undefined,
-      })
+      type BuildPayloadResult =
+        | { ok: true; payload: AgentProviderTestInput }
+        | { ok: false; error: string };
 
-      setTestStatus(result?.success ? 'success' : 'error')
+      const buildPayload = (): BuildPayloadResult => {
+        if (isCustom) {
+          const config = customProviderValues[customIndex];
+          if (!config) {
+            return { ok: false, error: 'Provider config is missing.' };
+          }
+          const apiKey = typeof config.apiKey === 'string' ? config.apiKey.trim() : '';
+          if (!apiKey) return { ok: false, error: 'API key is required.' };
+
+          const models = Array.isArray(config.models) ? config.models : [];
+          const firstEnabled = models.find((m) => m.enabled);
+          const modelId = firstEnabled?.id?.trim() || '';
+          if (!modelId) return { ok: false, error: 'Please enable at least one model to test.' };
+
+          return {
+            ok: true,
+            payload: {
+              providerId: activeProviderId,
+              apiKey,
+              baseUrl: config.baseUrl || undefined,
+              modelId,
+              sdkType: config.sdkType,
+            },
+          };
+        }
+
+        const config = providerValues[presetIndex];
+        if (!config) return { ok: false, error: 'Provider config is missing.' };
+
+        const apiKey = typeof config.apiKey === 'string' ? config.apiKey.trim() : '';
+        if (!apiKey) return { ok: false, error: 'API key is required.' };
+
+        const modelIds = allModels.map((m) => m.id);
+        const modelId = findFirstEnabledModelId(modelIds, (id, index) =>
+          isModelEnabledWithDefaultFirst(userModels, id, index)
+        );
+        if (!modelId) return { ok: false, error: 'Please enable at least one model to test.' };
+
+        return {
+          ok: true,
+          payload: {
+            providerId: activeProviderId,
+            apiKey,
+            baseUrl: config.baseUrl || undefined,
+            modelId,
+          },
+        };
+      };
+
+      const built = buildPayload();
+      if (!built.ok) {
+        toast.error(built.error);
+        setTestStatus('error');
+        scheduleTestStatusReset();
+        return;
+      }
+
+      const result = await window.desktopAPI.testAgentProvider(built.payload);
+
+      if (result?.success) {
+        toast.success(result.message || 'Connection successful.');
+        setTestStatus('success');
+      } else {
+        toast.error(result?.error || 'Test failed.');
+        setTestStatus('error');
+      }
     } catch {
-      setTestStatus('error')
+      toast.error('Test failed.');
+      setTestStatus('error');
     }
-    setTimeout(() => setTestStatus('idle'), 3000)
-  }, [isCustom, customProviderValues, customIndex, providerValues, presetIndex, activeProviderId])
+    scheduleTestStatusReset();
+  }, [
+    isCustom,
+    customProviderValues,
+    customIndex,
+    providerValues,
+    presetIndex,
+    activeProviderId,
+    preset,
+    allModels,
+    userModels,
+    scheduleTestStatusReset,
+  ]);
 
   // 添加自定义模型
-  const handleAddModel = useCallback((data: AddModelFormData) => {
-    if (presetIndex < 0) return
+  const handleAddModel = useCallback(
+    (data: AddModelFormData) => {
+      if (presetIndex < 0) return;
 
-    const currentModels = providerValues[presetIndex]?.models || []
-    setValue(`providers.${presetIndex}.models`, [
-      ...currentModels,
-      {
+      const currentModels = providerValues[presetIndex]?.models || [];
+      setValue(`providers.${presetIndex}.models`, [
+        ...currentModels,
+        {
+          id: data.id,
+          enabled: true,
+          isCustom: true,
+          customName: data.name,
+          customContext: data.contextSize,
+          customOutput: data.outputSize,
+          customCapabilities: data.capabilities,
+          customInputModalities: data.inputModalities,
+        },
+      ]);
+      // 添加模型意味着用户要用该服务商
+      setValue(`providers.${presetIndex}.enabled`, true);
+    },
+    [presetIndex, providerValues, setValue]
+  );
+
+  // 删除用户添加的自定义模型
+  const handleRemoveCustomModel = useCallback(
+    (index: number, modelId: string) => {
+      const currentModels = providerValues[index]?.models || [];
+      setValue(
+        `providers.${index}.models`,
+        currentModels.filter((m) => m.id !== modelId)
+      );
+    },
+    [providerValues, setValue]
+  );
+
+  // 打开编辑模型弹窗
+  const handleEditModel = useCallback(
+    (model: EditModelInitialData) => {
+      // 获取用户配置的输入模态
+      const userModel = userModels.find((m) => m.id === model.id);
+      setEditModelData({
+        ...model,
+        inputModalities: userModel?.customInputModalities || ['text'],
+      });
+      setEditModelOpen(true);
+    },
+    [userModels]
+  );
+
+  // 保存编辑的模型配置
+  const handleSaveModel = useCallback(
+    (data: EditModelFormData) => {
+      if (presetIndex < 0) return;
+
+      const currentModels = providerValues[presetIndex]?.models || [];
+      const existingIndex = currentModels.findIndex((m) => m.id === data.id);
+
+      const updatedModel = {
         id: data.id,
-        enabled: true,
-        isCustom: true,
+        enabled: existingIndex >= 0 ? currentModels[existingIndex].enabled : true,
+        // 标记为已自定义配置
+        isCustom: editModelData?.isCustom || false,
         customName: data.name,
         customContext: data.contextSize,
         customOutput: data.outputSize,
         customCapabilities: data.capabilities,
         customInputModalities: data.inputModalities,
-      },
-    ])
-  }, [presetIndex, providerValues, setValue])
+      };
 
-  // 删除用户添加的自定义模型
-  const handleRemoveCustomModel = useCallback((index: number, modelId: string) => {
-    const currentModels = providerValues[index]?.models || []
-    setValue(
-      `providers.${index}.models`,
-      currentModels.filter((m) => m.id !== modelId)
-    )
-  }, [providerValues, setValue])
+      if (existingIndex >= 0) {
+        // 更新已有配置
+        setValue(`providers.${presetIndex}.models.${existingIndex}`, updatedModel);
+      } else {
+        // 添加新配置（用于预设模型首次自定义）
+        setValue(`providers.${presetIndex}.models`, [...currentModels, updatedModel]);
+      }
+    },
+    [presetIndex, providerValues, setValue, editModelData]
+  );
 
-  // 打开编辑模型弹窗
-  const handleEditModel = useCallback((model: EditModelInitialData) => {
-    // 获取用户配置的输入模态
-    const userModel = userModels.find((m) => m.id === model.id)
-    setEditModelData({
-      ...model,
-      inputModalities: userModel?.customInputModalities || ['text'],
-    })
-    setEditModelOpen(true)
-  }, [userModels])
+  // 获取模型是否启用（对齐 agents-runtime：仅在“无任何显式配置”时默认启用第一个）
+  const isModelEnabled = useCallback(
+    (modelId: string, modelIndex: number) => {
+      return isModelEnabledWithDefaultFirst(userModels, modelId, modelIndex);
+    },
+    [userModels]
+  );
 
-  // 保存编辑的模型配置
-  const handleSaveModel = useCallback((data: EditModelFormData) => {
-    if (presetIndex < 0) return
+  // 自定义服务商模型管理
+  const handleAddCustomProviderModel = useCallback(
+    (data: { id: string; name: string }) => {
+      if (customIndex < 0) return;
+      const current = customProviderValues[customIndex];
+      const currentModels = Array.isArray(current?.models) ? current.models : [];
+      setValue(`customProviders.${customIndex}.models`, [
+        { id: data.id, name: data.name, enabled: true },
+        ...currentModels,
+      ]);
+      setValue(`customProviders.${customIndex}.enabled`, true);
+    },
+    [customIndex, customProviderValues, setValue]
+  );
 
-    const currentModels = providerValues[presetIndex]?.models || []
-    const existingIndex = currentModels.findIndex((m) => m.id === data.id)
+  const handleToggleCustomProviderModel = useCallback(
+    (modelId: string, enabled: boolean) => {
+      if (customIndex < 0) return;
+      const current = customProviderValues[customIndex];
+      const currentModels = Array.isArray(current?.models) ? current.models : [];
+      const nextModels = currentModels.map((m) => (m.id === modelId ? { ...m, enabled } : m));
+      setValue(`customProviders.${customIndex}.models`, nextModels);
+      if (enabled) {
+        setValue(`customProviders.${customIndex}.enabled`, true);
+      }
+    },
+    [customIndex, customProviderValues, setValue]
+  );
 
-    const updatedModel = {
-      id: data.id,
-      enabled: existingIndex >= 0 ? currentModels[existingIndex].enabled : true,
-      // 标记为已自定义配置
-      isCustom: editModelData?.isCustom || false,
-      customName: data.name,
-      customContext: data.contextSize,
-      customOutput: data.outputSize,
-      customCapabilities: data.capabilities,
-      customInputModalities: data.inputModalities,
-    }
-
-    if (existingIndex >= 0) {
-      // 更新已有配置
-      setValue(`providers.${presetIndex}.models.${existingIndex}`, updatedModel)
-    } else {
-      // 添加新配置（用于预设模型首次自定义）
-      setValue(`providers.${presetIndex}.models`, [...currentModels, updatedModel])
-    }
-  }, [presetIndex, providerValues, setValue, editModelData])
-
-  // 获取模型是否启用（默认只启用第一个预设模型）
-  const isModelEnabled = useCallback((modelId: string, modelIndex: number) => {
-    const modelConfig = userModels.find((m) => m.id === modelId)
-    if (modelConfig) {
-      return modelConfig.enabled
-    }
-    // 没有用户配置时，默认只启用第一个预设模型
-    return modelIndex === 0
-  }, [userModels])
+  const handleDeleteCustomProviderModel = useCallback(
+    (modelId: string) => {
+      if (customIndex < 0) return;
+      const current = customProviderValues[customIndex];
+      const currentModels = Array.isArray(current?.models) ? current.models : [];
+      setValue(
+        `customProviders.${customIndex}.models`,
+        currentModels.filter((m) => m.id !== modelId)
+      );
+    },
+    [customIndex, customProviderValues, setValue]
+  );
 
   // 空状态
   if (!activeProviderId) {
@@ -293,17 +512,17 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
       <div className="flex h-full items-center justify-center text-muted-foreground">
         {t('selectProviderPlaceholder')}
       </div>
-    )
+    );
   }
 
   // 会员模型详情
   if (isMembership) {
-    return <MembershipDetails />
+    return <MembershipDetails />;
   }
 
   // 渲染 Ollama 专属面板
   if (!isCustom && preset?.localBackend === 'ollama') {
-    return <OllamaPanel providers={providers} form={form} />
+    return <OllamaPanel providers={providers} form={form} />;
   }
 
   // 渲染预设服务商详情
@@ -314,7 +533,7 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
         <div className="flex h-full items-center justify-center text-muted-foreground">
           {t('loading')}
         </div>
-      )
+      );
     }
 
     return (
@@ -328,14 +547,22 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
                 <p className="text-sm text-muted-foreground mt-1">{preset.description}</p>
               )}
             </div>
-            <a
-              href={preset.docUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary hover:underline flex items-center gap-1 text-sm"
-            >
-              {t('documentation')} <ExternalLink className="h-3 w-3" />
-            </a>
+            <div className="flex flex-col items-end gap-2">
+              <ProviderEnabledToggle
+                enabled={Boolean(providerValues[presetIndex]?.enabled)}
+                onEnabledChange={(enabled) => setValue(`providers.${presetIndex}.enabled`, enabled)}
+                label="Provider enabled"
+                hint="Auto-enabled when you add an API key or enable a model."
+              />
+              <a
+                href={preset.docUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline flex items-center gap-1 text-sm"
+              >
+                {t('documentation')} <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
           </div>
 
           {/* API Key */}
@@ -395,15 +622,20 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
                   onChange={(e) => setSearchQuery(e.target.value)}
                 />
               </div>
-              <Button type="button" variant="outline" size="icon" onClick={() => setAddModelOpen(true)}>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => setAddModelOpen(true)}
+              >
                 <Plus className="h-4 w-4" />
               </Button>
             </div>
 
             {/* 模型列表 */}
             <div className="space-y-2 max-h-[300px] overflow-y-auto">
-              {filteredModels.map((model, modelIndex) => {
-                const isEnabled = isModelEnabled(model.id, modelIndex)
+              {filteredModels.map(({ model, index: modelIndex }) => {
+                const isEnabled = isModelEnabled(model.id, modelIndex);
 
                 return (
                   <div
@@ -459,27 +691,30 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
                         <Settings2 className="size-4" />
                       </button>
                       <Switch
-                      checked={isEnabled}
-                      onCheckedChange={(checked) => {
-                        if (presetIndex < 0) return
-                        const currentModels = providerValues[presetIndex]?.models || []
-                        const existingIndex = currentModels.findIndex((m) => m.id === model.id)
-                        if (existingIndex >= 0) {
-                          setValue(
-                            `providers.${presetIndex}.models.${existingIndex}.enabled`,
-                            checked
-                          )
-                        } else {
-                          setValue(`providers.${presetIndex}.models`, [
-                            ...currentModels,
-                            { id: model.id, enabled: checked },
-                          ])
-                        }
-                      }}
-                    />
+                        checked={isEnabled}
+                        onCheckedChange={(checked) => {
+                          if (presetIndex < 0) return;
+                          if (checked) {
+                            setValue(`providers.${presetIndex}.enabled`, true);
+                          }
+                          const currentModels = providerValues[presetIndex]?.models || [];
+                          const existingIndex = currentModels.findIndex((m) => m.id === model.id);
+                          if (existingIndex >= 0) {
+                            setValue(
+                              `providers.${presetIndex}.models.${existingIndex}.enabled`,
+                              checked
+                            );
+                          } else {
+                            setValue(`providers.${presetIndex}.models`, [
+                              ...currentModels,
+                              { id: model.id, enabled: checked },
+                            ]);
+                          }
+                        }}
+                      />
                     </div>
                   </div>
-                )
+                );
               })}
               {filteredModels.length === 0 && (
                 <div className="text-center text-sm text-muted-foreground py-4">
@@ -506,16 +741,25 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
           />
         </div>
       </ScrollArea>
-    )
+    );
   }
 
   // 渲染自定义服务商详情
   if (isCustom && customIndex >= 0) {
-    const config = customProviderValues[customIndex]
+    const config = customProviderValues[customIndex];
 
     return (
       <ScrollArea className="h-full">
         <div className="space-y-6 p-4">
+          <ProviderEnabledToggle
+            enabled={Boolean(config.enabled)}
+            onEnabledChange={(enabled) =>
+              setValue(`customProviders.${customIndex}.enabled`, enabled)
+            }
+            label="Provider enabled"
+            hint="Auto-enabled when you add an API key or enable a model."
+          />
+
           {/* 服务商名称 */}
           <div className="space-y-2">
             <Label htmlFor="custom-name">{t('customProviderNameLabel')}</Label>
@@ -532,7 +776,7 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
             <Select
               value={config.sdkType}
               onValueChange={(value: ProviderSdkType) => {
-                setValue(`customProviders.${customIndex}.sdkType`, value)
+                setValue(`customProviders.${customIndex}.sdkType`, value);
               }}
             >
               <SelectTrigger>
@@ -541,7 +785,9 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
               <SelectContent>
                 {SDK_TYPE_OPTIONS.map((option) => (
                   <SelectItem key={option.value} value={option.value}>
-                    {option.labelKey === 'sdkTypeOpenAICompatible' ? t(option.labelKey) : option.labelKey}
+                    {option.labelKey === 'sdkTypeOpenAICompatible'
+                      ? t(option.labelKey)
+                      : option.labelKey}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -582,6 +828,14 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
             />
           </div>
 
+          {/* Models */}
+          <CustomProviderModels
+            models={config.models || []}
+            onAddModel={handleAddCustomProviderModel}
+            onToggleModel={handleToggleCustomProviderModel}
+            onDeleteModel={handleDeleteCustomProviderModel}
+          />
+
           {/* 删除按钮 */}
           <div className="pt-4 border-t">
             <Button
@@ -596,12 +850,12 @@ export const ProviderDetails = ({ providers, form }: ProviderDetailsProps) => {
           </div>
         </div>
       </ScrollArea>
-    )
+    );
   }
 
   return (
     <div className="flex h-full items-center justify-center text-muted-foreground">
       {t('providerConfigLoading')}
     </div>
-  )
-}
+  );
+};

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-enabled-toggle.tsx
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-enabled-toggle.tsx
@@ -1,0 +1,34 @@
+/**
+ * [PROPS]: { enabled, onEnabledChange, label?, hint? }
+ * [EMITS]: onEnabledChange(enabled)
+ * [POS]: Providers 设置页通用的“启用/禁用服务商”展示组件（详情面板内显式展示开关）
+ *
+ * [PROTOCOL]: 本文件变更时，必须更新此 Header 及所属目录 CLAUDE.md
+ */
+
+import { Label } from '@anyhunt/ui/components/label';
+import { Switch } from '@anyhunt/ui/components/switch';
+
+type ProviderEnabledToggleProps = {
+  enabled: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+  label?: string;
+  hint?: string;
+};
+
+export const ProviderEnabledToggle = ({
+  enabled,
+  onEnabledChange,
+  label = 'Enabled',
+  hint,
+}: ProviderEnabledToggleProps) => {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2">
+      <div className="min-w-0">
+        <Label className="text-sm font-medium">{label}</Label>
+        {hint && <div className="text-xs text-muted-foreground">{hint}</div>}
+      </div>
+      <Switch checked={enabled} onCheckedChange={onEnabledChange} />
+    </div>
+  );
+};

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-list.tsx
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-list.tsx
@@ -1,56 +1,55 @@
-import { cn } from '@/lib/utils'
-import { Switch } from '@anyhunt/ui/components/switch'
-import { Button } from '@anyhunt/ui/components/button'
-import { Separator } from '@anyhunt/ui/components/separator'
-import { Plus } from 'lucide-react'
-import { getSortedProviders, getProviderById } from '@shared/model-registry'
-import type { SettingsDialogState } from '../../use-settings-dialog'
-import { useAuth, MEMBERSHIP_PROVIDER_ID } from '@/lib/server'
-import { useTranslation } from '@/lib/i18n'
+import { cn } from '@/lib/utils';
+import { Switch } from '@anyhunt/ui/components/switch';
+import { Button } from '@anyhunt/ui/components/button';
+import { Separator } from '@anyhunt/ui/components/separator';
+import { Plus } from 'lucide-react';
+import { getSortedProviders } from '@shared/model-registry';
+import type { SettingsDialogState } from '../../use-settings-dialog';
+import { useAuth, MEMBERSHIP_PROVIDER_ID } from '@/lib/server';
+import { useTranslation } from '@/lib/i18n';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { buildProviderOrder } from './provider-order';
 
-export { MEMBERSHIP_PROVIDER_ID }
+export { MEMBERSHIP_PROVIDER_ID };
 
 type ProviderListProps = {
-  providers: SettingsDialogState['providers']
-  form: SettingsDialogState['form']
-}
+  providers: SettingsDialogState['providers'];
+  form: SettingsDialogState['form'];
+};
 
 /**
- * 预设服务商列表
- * 显示所有预设服务商，点击可选中编辑
+ * Providers 列表
+ * 显示会员模型 +（预设服务商与自定义服务商合并）列表，启用的排在上方。
  */
 export const ProviderList = ({ providers, form }: ProviderListProps) => {
-  const { t } = useTranslation('settings')
+  const { t } = useTranslation('settings');
   const {
     providerValues,
     customProviderValues,
     activeProviderId,
     setActiveProviderId,
     handleAddCustomProvider,
-  } = providers
-  const { setValue } = form
-  const { isAuthenticated, user, membershipEnabled, setMembershipEnabled } = useAuth()
+  } = providers;
+  const { setValue } = form;
+  const { isAuthenticated, user, membershipEnabled, setMembershipEnabled } = useAuth();
 
-  const sortedPresets = getSortedProviders()
-  const isMembershipActive = activeProviderId === MEMBERSHIP_PROVIDER_ID
+  const sortedPresets = useMemo(() => getSortedProviders(), []);
+  const isMembershipActive = activeProviderId === MEMBERSHIP_PROVIDER_ID;
 
-  // 获取服务商是否启用和已配置
-  const getProviderStatus = (providerId: string) => {
-    const config = providerValues.find((p) => p.providerId === providerId)
-    return {
-      enabled: config?.enabled ?? false,
-      configured: Boolean(config?.apiKey?.trim()),
-    }
-  }
+  const presetProviderIds = useMemo(() => sortedPresets.map((p) => p.id), [sortedPresets]);
+  const customProviderIds = useMemo(
+    () => customProviderValues.map((p) => p.providerId),
+    [customProviderValues]
+  );
 
   // 切换预设服务商启用状态
   const handleToggleProvider = (providerId: string, enabled: boolean) => {
-    const index = providerValues.findIndex((p) => p.providerId === providerId)
+    const index = providerValues.findIndex((p) => p.providerId === providerId);
     if (index >= 0) {
-      setValue(`providers.${index}.enabled`, enabled)
+      setValue(`providers.${index}.enabled`, enabled);
     } else {
       // 如果还没有配置，添加新配置
-      const currentProviders = form.getValues('providers')
+      const currentProviders = form.getValues('providers');
       setValue('providers', [
         ...currentProviders,
         {
@@ -61,9 +60,67 @@ export const ProviderList = ({ providers, form }: ProviderListProps) => {
           models: [],
           defaultModelId: null,
         },
-      ])
+      ]);
     }
-  }
+  };
+
+  const isProviderEnabled = useCallback(
+    (providerId: string) => {
+      if (providerId.startsWith('custom-')) {
+        return customProviderValues.find((p) => p.providerId === providerId)?.enabled ?? false;
+      }
+      return providerValues.find((p) => p.providerId === providerId)?.enabled ?? false;
+    },
+    [customProviderValues, providerValues]
+  );
+
+  const desiredOrder = useMemo(() => {
+    return buildProviderOrder({
+      presetProviderIds,
+      customProviderIds,
+      isEnabled: (providerId) => isProviderEnabled(providerId),
+    });
+  }, [presetProviderIds, customProviderIds, isProviderEnabled]);
+
+  const desiredOrderRef = useRef<string[]>([]);
+  desiredOrderRef.current = desiredOrder;
+
+  // 仅维护顺序（不缓存 enabled/configured 等状态），避免编辑时列表跳动
+  const [providerOrder, setProviderOrder] = useState<string[]>(() => desiredOrder);
+  const lastCountRef = useRef<number>(presetProviderIds.length + customProviderIds.length);
+
+  // 初始化/增删 provider 时刷新顺序
+  useEffect(() => {
+    const count = presetProviderIds.length + customProviderIds.length;
+    if (lastCountRef.current !== count) {
+      setProviderOrder(desiredOrderRef.current);
+      lastCountRef.current = count;
+    }
+  }, [presetProviderIds.length, customProviderIds.length]);
+
+  // 延迟重排：仅当用户切换 active provider 时才刷新顺序（避免输入/自动启用导致跳动）
+  useEffect(() => {
+    if (!activeProviderId) return;
+    const count = presetProviderIds.length + customProviderIds.length;
+    setProviderOrder(desiredOrderRef.current);
+    lastCountRef.current = count;
+  }, [activeProviderId, presetProviderIds.length, customProviderIds.length]);
+
+  const presetById = useMemo(() => {
+    const map = new Map(sortedPresets.map((p) => [p.id, p]));
+    return map;
+  }, [sortedPresets]);
+
+  const customById = useMemo(() => {
+    const map = new Map(
+      customProviderValues.map((p, index) => [p.providerId, { config: p, index }])
+    );
+    return map;
+  }, [customProviderValues]);
+
+  const presetConfigById = useMemo(() => {
+    return new Map(providerValues.map((p) => [p.providerId, p]));
+  }, [providerValues]);
 
   return (
     <div className="flex h-full flex-col">
@@ -96,73 +153,55 @@ export const ProviderList = ({ providers, form }: ProviderListProps) => {
           </>
         )}
 
-        {/* 预设服务商 */}
+        {/* Providers（预设 + 自定义合并，启用的排前面） */}
         <div className="space-y-1 p-2">
-          {sortedPresets.map((preset) => {
-            const status = getProviderStatus(preset.id)
-            const isActive = activeProviderId === preset.id
+          {providerOrder.map((providerId) => {
+            const isCustom = providerId.startsWith('custom-');
+            const custom = isCustom ? customById.get(providerId) : undefined;
+            const preset = !isCustom ? presetById.get(providerId) : undefined;
+            if (!isCustom && !preset) return null;
+            if (isCustom && !custom) return null;
+
+            const isActive = activeProviderId === providerId;
+            const presetConfig = !isCustom ? presetConfigById.get(providerId) : undefined;
+            const enabled = isCustom
+              ? Boolean(custom?.config.enabled)
+              : Boolean(presetConfig?.enabled);
+
+            const configured = isCustom
+              ? Boolean(custom?.config.apiKey?.trim())
+              : Boolean(presetConfig?.apiKey?.trim());
+
+            const name = isCustom ? custom!.config.name : preset!.name;
 
             return (
               <div
-                key={preset.id}
+                key={providerId}
                 className={cn(
                   'flex items-center justify-between rounded-md px-3 py-2 cursor-pointer transition-colors',
                   isActive ? 'bg-accent' : 'hover:bg-accent/50'
                 )}
-                onClick={() => setActiveProviderId(preset.id)}
+                onClick={() => setActiveProviderId(providerId)}
               >
                 <div className="flex items-center gap-2 min-w-0">
-                  <span className="text-sm font-medium truncate">{preset.name}</span>
-                  {status.configured && (
-                    <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
-                  )}
+                  <span className="text-sm font-medium truncate">{name}</span>
+                  {configured && <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" />}
                 </div>
                 <Switch
-                  checked={status.enabled}
-                  onCheckedChange={(checked) => handleToggleProvider(preset.id, checked)}
+                  checked={enabled}
+                  onCheckedChange={(checked) => {
+                    if (isCustom) {
+                      setValue(`customProviders.${custom!.index}.enabled`, checked);
+                      return;
+                    }
+                    handleToggleProvider(providerId, checked);
+                  }}
                   onClick={(e) => e.stopPropagation()}
                 />
               </div>
-            )
+            );
           })}
         </div>
-
-        {/* 自定义服务商 */}
-        {customProviderValues.length > 0 && (
-          <>
-            <div className="px-3 py-2 text-xs font-medium text-muted-foreground">{t('customProviderSection')}</div>
-            <div className="space-y-1 px-2">
-              {customProviderValues.map((config, index) => {
-                const isActive = activeProviderId === config.providerId
-
-                return (
-                  <div
-                    key={config.providerId}
-                    className={cn(
-                      'flex items-center justify-between rounded-md px-3 py-2 cursor-pointer transition-colors',
-                      isActive ? 'bg-accent' : 'hover:bg-accent/50'
-                    )}
-                    onClick={() => setActiveProviderId(config.providerId)}
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <span className="text-sm font-medium truncate">{config.name}</span>
-                      {config.apiKey && (
-                        <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
-                      )}
-                    </div>
-                    <Switch
-                      checked={config.enabled}
-                      onCheckedChange={(checked) => {
-                        setValue(`customProviders.${index}.enabled`, checked)
-                      }}
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                  </div>
-                )
-              })}
-            </div>
-          </>
-        )}
       </div>
 
       {/* 添加自定义服务商按钮 */}
@@ -178,5 +217,5 @@ export const ProviderList = ({ providers, form }: ProviderListProps) => {
         </Button>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-models.ts
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-models.ts
@@ -1,0 +1,39 @@
+/**
+ * [PROVIDES]: isModelEnabledWithDefaultFirst, findFirstEnabledModelId
+ * [DEPENDS]: none (pure)
+ * [POS]: Providers 设置页的模型启用策略与“取第一个启用模型”逻辑，供 UI 和测试按钮复用
+ *
+ * [PROTOCOL]: 本文件变更时，必须更新此 Header 及所属目录 CLAUDE.md
+ */
+
+export type MinimalUserModelConfig = { id: string; enabled: boolean };
+
+/**
+ * 判断模型是否启用（对齐 agents-runtime 的默认策略）：
+ * - 当用户还没有任何显式模型配置时：默认只启用列表中的第一个模型
+ * - 一旦用户显式配置过任意模型：仅以显式配置为准，未配置的模型视为禁用
+ */
+export const isModelEnabledWithDefaultFirst = (
+  userModels: MinimalUserModelConfig[],
+  modelId: string,
+  modelIndex: number
+): boolean => {
+  const modelConfig = userModels.find((m) => m.id === modelId);
+  if (modelConfig) return Boolean(modelConfig.enabled);
+  if (userModels.length > 0) return false;
+  return modelIndex === 0;
+};
+
+/**
+ * 按传入顺序找到第一个启用模型 ID（用于“基于用户开启模型的第一个进行测试”）。
+ */
+export const findFirstEnabledModelId = (
+  modelIds: string[],
+  isEnabled: (modelId: string, modelIndex: number) => boolean
+): string | null => {
+  for (let i = 0; i < modelIds.length; i++) {
+    const id = modelIds[i];
+    if (isEnabled(id, i)) return id;
+  }
+  return null;
+};

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-order.ts
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-order.ts
@@ -1,0 +1,36 @@
+/**
+ * [PROVIDES]: buildProviderOrder
+ * [DEPENDS]: none (pure)
+ * [POS]: Providers 左侧列表排序策略（避免 UI 在编辑中频繁跳动，仅在外层触发时刷新顺序）
+ *
+ * [PROTOCOL]: 本文件变更时，必须更新此 Header 及所属目录 CLAUDE.md
+ */
+
+export type BuildProviderOrderInput = {
+  /** 预设服务商 ID（按 registry 默认顺序） */
+  presetProviderIds: string[];
+  /** 自定义服务商 ID（按创建顺序） */
+  customProviderIds: string[];
+  /** 是否启用 */
+  isEnabled: (providerId: string) => boolean;
+};
+
+/**
+ * 构建 Providers 列表顺序：
+ * - Enabled 全部排在上面
+ * - Disabled 全部排在下面
+ * - 同一状态内保持原有顺序稳定（预设按 registry，自定义按创建顺序）
+ */
+export const buildProviderOrder = (input: BuildProviderOrderInput): string[] => {
+  const base = [...input.presetProviderIds, ...input.customProviderIds];
+
+  const enabled: string[] = [];
+  const disabled: string[] = [];
+
+  for (const id of base) {
+    if (input.isEnabled(id)) enabled.push(id);
+    else disabled.push(id);
+  }
+
+  return [...enabled, ...disabled];
+};


### PR DESCRIPTION
Providers testing now uses the first enabled model instead of hard-coded defaults, and providers auto-enable when you enter an API key or enable a model. Custom providers can manage models (add/enable/disable/delete) and the details view exposes a clear provider enabled toggle. The provider list merges preset and custom providers and keeps enabled providers at the top without jumping during edits.