### PR TITLE
fix(moryflow/pc): reorder providers after load

### DIFF
--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers-section.tsx
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers-section.tsx
@@ -1,17 +1,18 @@
-import type { SettingsDialogState } from '../use-settings-dialog'
-import { ProviderList } from './providers/provider-list'
-import { ProviderDetails } from './providers/provider-details'
+import type { SettingsDialogState } from '../use-settings-dialog';
+import { ProviderList } from './providers/provider-list';
+import { ProviderDetails } from './providers/provider-details';
 
 type ProvidersSectionProps = {
-  providers: SettingsDialogState['providers']
-  form: SettingsDialogState['form']
-}
+  providers: SettingsDialogState['providers'];
+  form: SettingsDialogState['form'];
+  isLoading: boolean;
+};
 
-export const ProvidersSection = ({ providers, form }: ProvidersSectionProps) => (
+export const ProvidersSection = ({ providers, form, isLoading }: ProvidersSectionProps) => (
   <div className="flex h-full gap-4">
     {/* 左侧服务商列表 */}
     <div className="w-64 shrink-0 rounded-xl border bg-muted/30">
-      <ProviderList providers={providers} form={form} />
+      <ProviderList providers={providers} form={form} isLoading={isLoading} />
     </div>
 
     {/* 右侧详情面板 */}
@@ -19,4 +20,4 @@ export const ProvidersSection = ({ providers, form }: ProvidersSectionProps) => 
       <ProviderDetails providers={providers} form={form} />
     </div>
   </div>
-)
+);

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-list.tsx
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/providers/provider-list.tsx
@@ -15,13 +15,14 @@ export { MEMBERSHIP_PROVIDER_ID };
 type ProviderListProps = {
   providers: SettingsDialogState['providers'];
   form: SettingsDialogState['form'];
+  isLoading: boolean;
 };
 
 /**
  * Providers 列表
  * 显示会员模型 +（预设服务商与自定义服务商合并）列表，启用的排在上方。
  */
-export const ProviderList = ({ providers, form }: ProviderListProps) => {
+export const ProviderList = ({ providers, form, isLoading }: ProviderListProps) => {
   const { t } = useTranslation('settings');
   const {
     providerValues,
@@ -121,6 +122,17 @@ export const ProviderList = ({ providers, form }: ProviderListProps) => {
   const presetConfigById = useMemo(() => {
     return new Map(providerValues.map((p) => [p.providerId, p]));
   }, [providerValues]);
+
+  // 设置加载完成后刷新一次顺序，确保首次进入就满足“启用在上”的规则。
+  // 用户编辑过程中（包括自动启用）不跟随 enabled 变化重排，避免列表跳动。
+  const prevIsLoadingRef = useRef<boolean>(isLoading);
+  useEffect(() => {
+    const prev = prevIsLoadingRef.current;
+    prevIsLoadingRef.current = isLoading;
+    if (prev && !isLoading) {
+      setProviderOrder(desiredOrderRef.current);
+    }
+  }, [isLoading]);
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/moryflow/pc/src/renderer/components/settings-dialog/components/section-content.tsx
+++ b/apps/moryflow/pc/src/renderer/components/settings-dialog/components/section-content.tsx
@@ -1,28 +1,28 @@
-import type { UseFieldArrayReturn } from 'react-hook-form'
-import type { FormValues, SettingsSection } from '../const'
-import type { SettingsDialogState } from '../use-settings-dialog'
-import { AccountSection } from './account-section'
-import { GeneralSection } from './general-section'
-import { ProvidersSection } from './providers-section'
-import { McpSection } from './mcp-section'
-import { CloudSyncSection } from './cloud-sync-section'
-import { AboutSection } from './about-section'
-import { LoadingHint } from './shared'
+import type { UseFieldArrayReturn } from 'react-hook-form';
+import type { FormValues, SettingsSection } from '../const';
+import type { SettingsDialogState } from '../use-settings-dialog';
+import { AccountSection } from './account-section';
+import { GeneralSection } from './general-section';
+import { ProvidersSection } from './providers-section';
+import { McpSection } from './mcp-section';
+import { CloudSyncSection } from './cloud-sync-section';
+import { AboutSection } from './about-section';
+import { LoadingHint } from './shared';
 
 type SectionContentProps = {
-  section: SettingsSection
+  section: SettingsSection;
   meta: {
-    isLoading: boolean
-    appVersion: string | null
-  }
-  form: SettingsDialogState['form']
-  providers: SettingsDialogState['providers']
+    isLoading: boolean;
+    appVersion: string | null;
+  };
+  form: SettingsDialogState['form'];
+  providers: SettingsDialogState['providers'];
   mcp: {
-    stdioArray: UseFieldArrayReturn<FormValues, 'mcp.stdio'>
-    httpArray: UseFieldArrayReturn<FormValues, 'mcp.streamableHttp'>
-  }
-  vaultPath?: string | null
-}
+    stdioArray: UseFieldArrayReturn<FormValues, 'mcp.stdio'>;
+    httpArray: UseFieldArrayReturn<FormValues, 'mcp.streamableHttp'>;
+  };
+  vaultPath?: string | null;
+};
 
 /**
  * 按当前选项渲染具体的设置区域。
@@ -36,17 +36,17 @@ export const SectionContent = ({
   vaultPath,
 }: SectionContentProps) => {
   if (section === 'account') {
-    return <AccountSection />
+    return <AccountSection />;
   }
   if (section === 'general') {
     return meta.isLoading ? (
       <LoadingHint text="正在加载配置…" />
     ) : (
       <GeneralSection control={form.control} />
-    )
+    );
   }
   if (section === 'providers') {
-    return <ProvidersSection providers={providers} form={form} />
+    return <ProvidersSection providers={providers} form={form} isLoading={meta.isLoading} />;
   }
   if (section === 'mcp') {
     return (
@@ -59,10 +59,10 @@ export const SectionContent = ({
         setValue={form.setValue}
         isLoading={meta.isLoading}
       />
-    )
+    );
   }
   if (section === 'cloud-sync') {
-    return <CloudSyncSection vaultPath={vaultPath} />
+    return <CloudSyncSection vaultPath={vaultPath} />;
   }
-  return <AboutSection appVersion={meta.appVersion} />
-}
+  return <AboutSection appVersion={meta.appVersion} />;
+};


### PR DESCRIPTION
Ensures the Providers list is reordered once after settings finish loading, so enabled providers appear on top immediately.
This matches the UX expectation from PR #39 review feedback.